### PR TITLE
Fix filename that gets generated from dbe:migrations

### DIFF
--- a/src/Nwidart/DbExporter/DbMigrations.php
+++ b/src/Nwidart/DbExporter/DbMigrations.php
@@ -54,7 +54,7 @@ class DbMigrations extends DbExporter
         $filename = date('Y_m_d_His') . "_create_" . $this->database . "_database.php";
         self::$filePath = Config::get('db-exporter::export_path.migrations')."{$filename}";
 
-        file_put_contents(self::$filePath."{$filename}", $schema);
+        file_put_contents(self::$filePath, $schema);
 
         return self::$filePath;
     }


### PR DESCRIPTION
Hey,

php artisan dbe:migrations --ignore="table1,table2"

The filename is wrong when the file is generated:
./app/database/migrations/2014_08_04_223950_create_mysite_database.php2014_08_04_223950_create_mysite_database.php

The expected result is:
./app/database/migrations/2014_08_04_223950_create_mysite_database.php

This pull request fixes it.
Thanks
