### PR TITLE
Updates to make package compatible with Laravel 5.1

### DIFF
--- a/src/Nwidart/DbExporter/Commands/CopyToRemoteCommand.php
+++ b/src/Nwidart/DbExporter/Commands/CopyToRemoteCommand.php
@@ -98,7 +98,7 @@ class CopyToRemoteCommand extends GeneratorCommand
         $localPath = "{$what}Path";
 
         $dir = scandir($this->$localPath);
-        $remotePath = Config::get('db-exporter::remote.'.$what);
+        $remotePath = config('db-exporter.remote.'.$what);
 
         // Prepare the progress bar
         $progress = $this->getHelperSet()->get('progress');

--- a/src/Nwidart/DbExporter/Commands/GeneratorCommand.php
+++ b/src/Nwidart/DbExporter/Commands/GeneratorCommand.php
@@ -11,8 +11,8 @@ class GeneratorCommand extends Command
      */
     protected function getDatabaseName()
     {
-        $connType = Config::get('database.default');
-        $database = Config::get('database.connections.' .$connType );
+        $connType = config('database.default');
+        $database = config('database.connections.' .$connType );
 
         return $database['database'];
     }

--- a/src/Nwidart/DbExporter/Commands/SeedGeneratorCommand.php
+++ b/src/Nwidart/DbExporter/Commands/SeedGeneratorCommand.php
@@ -54,7 +54,7 @@ class SeedGeneratorCommand extends GeneratorCommand
     private function getFilename()
     {
         $filename = Str::camel($this->getDatabaseName()) . "TableSeeder";
-        return Config::get('db-exporter::export_path.seeds')."{$filename}.php";
+        return config('db-exporter.export_path.seeds')."{$filename}.php";
     }
 
     protected function getOptions()

--- a/src/Nwidart/DbExporter/DbExportHandlerServiceProvider.php
+++ b/src/Nwidart/DbExporter/DbExportHandlerServiceProvider.php
@@ -24,7 +24,7 @@ class DbExportHandlerServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->package('nwidart/db-exporter');
+        $this->publishes([__DIR__.'/../../config/config.php' => config_path('db-exporter.php')], 'config');
     }
 
     public function register()
@@ -40,6 +40,11 @@ class DbExportHandlerServiceProvider extends ServiceProvider
 
         // Load the alias
         $this->loadAlias();
+
+        // Default config
+        $this->mergeConfigFrom(
+            __DIR__.'/../../config/config.php', 'db-exporter'
+        );
     }
 
     /**
@@ -63,8 +68,8 @@ class DbExportHandlerServiceProvider extends ServiceProvider
      */
     private function getDatabaseName()
     {
-        $connType = Config::get('database.default');
-        $database = Config::get('database.connections.' .$connType );
+        $connType = config('database.default');
+        $database = config('database.connections.' .$connType );
 
         return $database['database'];
     }
@@ -139,6 +144,11 @@ class DbExportHandlerServiceProvider extends ServiceProvider
         {
             $loader = \Illuminate\Foundation\AliasLoader::getInstance();
             $loader->alias('DbExportHandler', 'Nwidart\DbExporter\Facades\DbExportHandler');
+
+            // some users migrating from 5.0 don't have Str alias registered
+            if (! class_exists('\Str')) {
+                $loader->alias('Str',\Illuminate\Support\Str::class);
+            }
         });
     }
 

--- a/src/Nwidart/DbExporter/DbMigrations.php
+++ b/src/Nwidart/DbExporter/DbMigrations.php
@@ -52,7 +52,7 @@ class DbMigrations extends DbExporter
 
         $schema = $this->compile();
         $filename = date('Y_m_d_His') . "_create_" . $this->database . "_database.php";
-        self::$filePath = Config::get('db-exporter::export_path.migrations')."{$filename}";
+        self::$filePath = config('db-exporter.export_path.migrations')."{$filename}";
 
         file_put_contents(self::$filePath, $schema);
 

--- a/src/Nwidart/DbExporter/DbMigrationsServiceProvider.php
+++ b/src/Nwidart/DbExporter/DbMigrationsServiceProvider.php
@@ -19,7 +19,7 @@ class DbMigrationsServiceProvider extends ServiceProvider {
      */
     public function boot()
     {
-        $this->package('nwidart/db-exporter');
+        //
     }
 
     /**
@@ -32,8 +32,8 @@ class DbMigrationsServiceProvider extends ServiceProvider {
 
         $this->app['DbMigrations'] = $this->app->share(function()
         {
-            $connType = Config::get('database.default');
-            $database = Config::get('database.connections.' .$connType );
+            $connType = config('database.default');
+            $database = config('database.connections.' .$connType );
             return new DbMigrations($database);
         });
 

--- a/src/Nwidart/DbExporter/DbSeeding.php
+++ b/src/Nwidart/DbExporter/DbSeeding.php
@@ -43,7 +43,7 @@ class DbSeeding extends DbExporter
 
         $filename = Str::camel($this->database) . "TableSeeder";
 
-        file_put_contents(Config::get('db-exporter::export_path.seeds')."{$filename}.php", $seed);
+        file_put_contents(config('db-exporter.export_path.seeds')."{$filename}.php", $seed);
     }
 
     /**

--- a/src/Nwidart/DbExporter/Server.php
+++ b/src/Nwidart/DbExporter/Server.php
@@ -19,7 +19,7 @@ class Server
         $localPath = "{$what}Path";
 
         $dir = scandir($localPath);
-        $remotePath = Config::get('db-exporter::remote.' . $what);
+        $remotePath = config('db-exporter.remote.' . $what);
 
         foreach($dir as $file) {
             if (in_array($file, $this->ignoredFiles)) {
@@ -42,6 +42,6 @@ class Server
     private function getRemoteName()
     {
         // For now static from he config file.
-        return Config::get('db-exporter::remote.name');
+        return config('db-exporter.remote.name');
     }
 }


### PR DESCRIPTION
Main changes in this pull request:
1. Update `DbExportHandlerServiceProvider::boot()` and `::register()` methods to use the L5 config publishes() style. This allows the config to get published via `php artisan vendor:publish`.
2. Remove the `$this->package('nwidart/db-exporter');` call from `DbMigrationsServiceProvider::boot()` method. It's enough to have it publishes() call in the export handler, so leave it empty.
3. Register \Str alias in `DbExportHandlerServiceProvider::loadAlias()` because some users won't have \Str alias registered in their config/app.php, and you're already going the extra mile, so might as well do it for \Str too.
4. Replace config strings using L4 style, e.g. `Config::get('db-exporter::export_path.seeds')` --> `config('db-exporter.export_path.seeds')`
5. Replace Config::get() with config() just to be more consistent with Laravel docs.