### PR TITLE
Add json Data Type & solve database name issues

### DIFF
--- a/src/Nwidart/DbExporter/DbExporter.php
+++ b/src/Nwidart/DbExporter/DbExporter.php
@@ -24,7 +24,7 @@ abstract class DbExporter
     public function getTableIndexes($table)
     {
         $pdo = DB::connection()->getPdo();
-        return $pdo->query('SHOW INDEX FROM ' . $table . ' WHERE Key_name != "PRIMARY"');
+        return $pdo->query('SHOW INDEX FROM ' . $this->database . '.' . $table . ' WHERE Key_name != "PRIMARY"');
     }
 
     /**

--- a/src/Nwidart/DbExporter/DbMigrations.php
+++ b/src/Nwidart/DbExporter/DbMigrations.php
@@ -158,6 +158,9 @@ class DbMigrations extends DbExporter
                         $options = substr($values->Type, $para + 1, -1);
                         $numbers = ', array(' . $options . ')';
                         break;
+                    case 'json' :
+                        $method = 'json';
+                        break;
                 }
 
                 if ($values->Key == 'PRI') {


### PR DESCRIPTION
This error appeared to me :
 [PDOException]                                                                                                                             
  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your M  
  ySQL server version for the right syntax to use near 'desc WHERE Key_name != "PRIMARY"' at line 1

And The solution is to change line 27 in DBExporter  to Be 

return $pdo->query('SHOW INDEX FROM ' . $this->database . '.' . $table . ' WHERE Key_name != "PRIMARY"');


second issues Their is new data type in mysql  is json DataType : and 
This lines added in DbMigrations.php

  case 'json' :
                        $method = 'json';
                        break;
 
    
    

